### PR TITLE
Fix ‘getMeta’ keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to `securemessage` will be documented in this file.
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
 ## Unreleased
-[Compare v0.1.1 - Unreleased](https://github.com/exonet/securemessage/compare/v0.1.1...develop)
+[Compare v0.1.2 - Unreleased](https://github.com/exonet/securemessage/compare/v0.1.2...develop)
+
+## [v0.1.2](https://github.com/exonet/securemessage/releases/tag/v0.1.2) - 2018-10-03
+[Compare v0.1.1 - v0.1.2](https://github.com/exonet/securemessage/compare/v0.1.1...v0.1.2)
+
+### Fixed
+- When using the 'getMeta' function of the Laravel adapter the keys are now set correctly.
 
 ## [v0.1.1](https://github.com/exonet/securemessage/releases/tag/v0.1.1) - 2018-07-25
 [Compare v0.1.0 - v0.1.1](https://github.com/exonet/securemessage/compare/v0.1.0...v0.1.1)

--- a/src/Laravel/Factory.php
+++ b/src/Laravel/Factory.php
@@ -238,7 +238,17 @@ class Factory
         // Build the SecureMessage as required by the Crypto utility, but only with the data for decrypting the meta.
         $secureMessage = new SecureMessage();
         $secureMessage->setId($record->id);
+        $secureMessage->setDatabaseKey($this->laravelEncryption->decrypt($record->key));
         $secureMessage->setEncryptedMeta($this->laravelEncryption->decrypt($record->meta));
+        
+        // Check if the storage key file exists.
+        if (!$this->storage->exists($record->id)) {
+            throw new DecryptException('Can not find key file.');
+        }
+
+        // Read and set the storage key.
+        $secureMessage->setStorageKey($this->laravelEncryption->decrypt($this->storage->get($record->id)));
+
 
         // Decrypt the meta data.
         $meta = $this->secureMessageFactory->decryptMeta($secureMessage);

--- a/src/Laravel/Factory.php
+++ b/src/Laravel/Factory.php
@@ -240,7 +240,7 @@ class Factory
         $secureMessage->setId($record->id);
         $secureMessage->setDatabaseKey($this->laravelEncryption->decrypt($record->key));
         $secureMessage->setEncryptedMeta($this->laravelEncryption->decrypt($record->meta));
-        
+
         // Check if the storage key file exists.
         if (!$this->storage->exists($record->id)) {
             throw new DecryptException('Can not find key file.');
@@ -248,7 +248,6 @@ class Factory
 
         // Read and set the storage key.
         $secureMessage->setStorageKey($this->laravelEncryption->decrypt($this->storage->get($record->id)));
-
 
         // Decrypt the meta data.
         $meta = $this->secureMessageFactory->decryptMeta($secureMessage);


### PR DESCRIPTION
## Description
When using the 'getMeta' function of the Laravel adapter the keys are now set correctly.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
