### PR TITLE
Define git archive excludes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.github/               export-ignore
+docs/                  export-ignore
+tests/                 export-ignore
+.gitattributes         export-ignore
+.gitignore             export-ignore
+.php-cs-fixer.php      export-ignore
+phpunit.xml            export-ignore


### PR DESCRIPTION
## Description
Add a `.gitattributes` file that defines which files to exclude in when running `git archive`.

When composer-installing this package now only the following files are downloaded:
- src/
- composer.json
- LICENSE.md
- README.md

More info on export-ignore via gitattributes: https://git-scm.com/docs/gitattributes#_export_ignore

## Motivation and context
This reduces the size of the package when installing via composer. Files that are not needed to run the package in another project are no longer included. For example the tests.

## How has this been tested?

Run `git archive -o latest.zip HEAD` and see the zip archive no longer contains things like tests.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [X] I have read the **[CONTRIBUTING](../.github/CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] My pull request contains a title that can be used as a release note.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- ~I have added tests to cover my changes.~
- [X] If my change requires a change to the documentation, I have updated it accordingly.